### PR TITLE
Fix imports optimization in RemoveAnnotationVisitor

### DIFF
--- a/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
+++ b/rewrite-java/src/main/java/org/openrewrite/java/RemoveAnnotationVisitor.java
@@ -158,7 +158,7 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
                 Expression expression = assignment.getAssignment();
                 maybeRemoveImportFromExpression(expression);
             } else {
-                maybeRemoveImport(TypeUtils.asFullyQualified(argument.getType()));
+                maybeRemoveImportFromExpression(argument);
             }
         });
     }
@@ -173,7 +173,10 @@ public class RemoveAnnotationVisitor extends JavaIsoVisitor<ExecutionContext> {
             if (fieldType != null) {
                 maybeRemoveImport(TypeUtils.asFullyQualified(fieldType.getOwner()));
             }
-        } else {
+        } else { 
+            if (expression instanceof J.Annotation) {
+                maybeRemoveAnnotationParameterImports((J.Annotation) expression);
+            }
             maybeRemoveImport(TypeUtils.asFullyQualified(expression.getType()));
         }
     }


### PR DESCRIPTION
I am using the org.openrewrite.java.RemoveAnnotation rewrite, which usually removes dead imports. In some cases it does not queue the RemoveImport op correctly.

The following two cases currently are not covered.

Expressions without named params:  

    @Anno(value = {Foo.class, Bar.class}) // Works
    @Anno({Foo.class, Bar.class}) // Catches Anno, Misses Foo and Bar

Annotation parameters are only traversed at the top-level, not the recursive case:

    @X(value=@Y(Z.class))  // Catches X and Y, Misses Z